### PR TITLE
Patch: correct broken link in WMS layer URL sample README

### DIFF
--- a/ogc/wms-layer-url/README.md
+++ b/ogc/wms-layer-url/README.md
@@ -18,15 +18,15 @@ The map will load automatically when the sample starts.
     * **Note**: The name comes from the 'Name' property, not the 'Title' property. On many services, the title is human-readable while the name is a numeric identifier.
 2. Add the layer to the map as an operational layer with `map.getOperationalLayers().add(wmsLayer)`.
 
-## About the data
-
-This sample uses a [U.S. National Weather Service radar map](https://nowcoast.noaa.gov/geoserver/observations/weather_radar/wms). Because WMS services generate map images on-the-fly, this layer is always up-to-date with the latest NOAA nowCOAST real-time coastal observations, forecasts, and warnings.
-
 ## Relevant API
 
 * ArcGISMap
 * MapView
 * WmsLayer
+
+## About the data
+
+This sample uses a [U.S. National Weather Service radar map](https://nowcoast.noaa.gov/geoserver/observations/weather_radar/wms). Because WMS services generate map images on-the-fly, this layer is always up-to-date with the latest NOAA nowCOAST real-time coastal observations, forecasts, and warnings.
 
 ## Tags
 

--- a/ogc/wms-layer-url/README.md
+++ b/ogc/wms-layer-url/README.md
@@ -20,7 +20,7 @@ The map will load automatically when the sample starts.
 
 ## About the data
 
-This sample uses a [U.S. National Weather Service radar map](https://nowcoast.noaa.gov/geoserver/observations/weather_radar/wms). Because WMS services generate map images on-the-fly, this layer is always up-to-date with the latest [NOAA NEXRAD radar](https://www.ncdc.noaa.gov/data-access/radar-data/nexrad) observations.
+This sample uses a [U.S. National Weather Service radar map](https://nowcoast.noaa.gov/geoserver/observations/weather_radar/wms). Because WMS services generate map images on-the-fly, this layer is always up-to-date with the latest NOAA nowCOAST real-time coastal observations, forecasts, and warnings.
 
 ## Relevant API
 

--- a/ogc/wms-layer-url/README.metadata.json
+++ b/ogc/wms-layer-url/README.metadata.json
@@ -7,8 +7,8 @@
     ],
     "keywords": [
         "OGC",
-        "WMS",
         "web map service",
+        "WMS",
         "ArcGISMap",
         "MapView",
         "WmsLayer"


### PR DESCRIPTION
### Description

The [WMS layer (URL)](https://next.sites.afd.arcgis.com/java/sample-code/wms-layer-url/#about-the-data) sample currently references a broken link (https://www.ncdc.noaa.gov/data-access/radar-data/nexrad).

This PR replaces it with wording already in use by the [.NET](https://next.sites.afd.arcgis.com/net/wpf/sample-code/wms-layer-url/#about-the-data) and [Qt](https://next.sites.afd.arcgis.com/qt/cpp/sample-code/wms-layer-url/#about-the-data) samples.

cc @steverozic 

Checklist:
- [x] Set target branch to main (current release) or v.next (next release)
- [x] Request a reviewer
- [x] Assign a reviewer
- [x] Tag reviewer in comment
